### PR TITLE
feat: box Claude auth via subscription OAuth token (setup-token)

### DIFF
--- a/bwh_hive/bwh_hive/doctype/hive_settings/hive_settings.json
+++ b/bwh_hive/bwh_hive/doctype/hive_settings/hive_settings.json
@@ -26,6 +26,7 @@
   "default_agent_template_slug",
   "skills_repo",
   "anthropic_api_key",
+  "claude_code_oauth_token",
   "agent_prompts_section",
   "agent_spec_prompt",
   "agent_implement_prompt",
@@ -170,10 +171,16 @@
    "label": "Skills Repo"
   },
   {
-   "description": "Injected into boxes as ANTHROPIC_API_KEY for Claude Code.",
+   "description": "Injected into boxes as ANTHROPIC_API_KEY for Claude Code (API billing).",
    "fieldname": "anthropic_api_key",
    "fieldtype": "Password",
    "label": "Anthropic API Key"
+  },
+  {
+   "description": "Claude subscription token from `claude setup-token`. Injected as CLAUDE_CODE_OAUTH_TOKEN. Used only when no Anthropic API Key is set — lets boxes auth via a Claude subscription instead of API billing.",
+   "fieldname": "claude_code_oauth_token",
+   "fieldtype": "Password",
+   "label": "Claude Code OAuth Token"
   },
   {
    "collapsible": 1,

--- a/bwh_hive/bwh_hive/orchestrator/service.py
+++ b/bwh_hive/bwh_hive/orchestrator/service.py
@@ -120,6 +120,13 @@ def build_boot_env(task: Document) -> dict:
 	spec_run_timeout = max(spec_min - 5, 5) * 60
 	impl_run_timeout = max(impl_min - 5, 5) * 60
 
+	# Claude auth: an Anthropic API key (API billing) OR a subscription OAuth token from
+	# `claude setup-token`. The box's claude falls back to the OAuth token when
+	# ANTHROPIC_API_KEY is empty, so only forward the token when no API key is set —
+	# never both, to avoid an ambiguous auth mode.
+	anthropic_api_key = settings.get_password("anthropic_api_key", raise_exception=False) or ""
+	oauth_token = settings.get_password("claude_code_oauth_token", raise_exception=False) or ""
+
 	env = {
 		"AGENT_MODE": "1",
 		"HIVE_BASE_URL": frappe.utils.get_url(),
@@ -134,7 +141,8 @@ def build_boot_env(task: Document) -> dict:
 		"TARGET_APP_REPO": project.get("target_app_repo") or "",
 		"TARGET_APP_BRANCH": project.get("target_app_branch") or "develop",
 		"SKILLS_REPO": skills_repo or "",
-		"ANTHROPIC_API_KEY": settings.get_password("anthropic_api_key", raise_exception=False) or "",
+		"ANTHROPIC_API_KEY": anthropic_api_key,
+		"CLAUDE_CODE_OAUTH_TOKEN": oauth_token if not anthropic_api_key else "",
 		"SPEC_RUN_TIMEOUT": spec_run_timeout,
 		"IMPL_RUN_TIMEOUT": impl_run_timeout,
 	}


### PR DESCRIPTION
Lets agent boxes authenticate Claude via a **Claude subscription** instead of an Anthropic API key — unblocks running the agent when API access isn't available (the whole v2 test-server validation ran on subscription creds).

## What
- New **Claude Code OAuth Token** (Password) field on **Hive Settings**.
- `build_boot_env` forwards it to boxes as `CLAUDE_CODE_OAUTH_TOKEN`, **only when `anthropic_api_key` is empty** (so the two auth modes never conflict).

## Why no box/golden change is needed
- `devbox-init.sh` writes MMDS env generically (`(.env) | to_entries | map("export "+.key…)`), so a new boot_env key flows into the box shell automatically.
- When `ANTHROPIC_API_KEY` is empty, `claude` falls back to `CLAUDE_CODE_OAUTH_TOKEN`.

## Usage
1. `claude setup-token` locally → long-lived subscription token.
2. Paste into **Hive Settings → Claude Code OAuth Token**, save.
3. Assign a task → boxes auth hands-off. Switch to the API key later by filling `anthropic_api_key` and clearing this field.

## Validation
- `hive_settings.json` valid; `service.py` compiles; **migrate clean on `pms.localhost`** — field present as Password. Auth branch: API-key-set → forwards `ANTHROPIC_API_KEY` only; API-key-empty → forwards `CLAUDE_CODE_OAUTH_TOKEN` only.

Deploys via Frappe Cloud on merge (adds the field on migrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)